### PR TITLE
Workaround post data size limitation (#19)

### DIFF
--- a/lic/corefx/LICENSE.txt
+++ b/lic/corefx/LICENSE.txt
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Core/FormUrlEncodedContent.cs
+++ b/src/Core/FormUrlEncodedContent.cs
@@ -1,0 +1,77 @@
+#region Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// https://github.com/dotnet/corefx/blob/e0ba7aa8026280ee3571179cc06431baf1dfaaac/LICENSE.TXT
+//
+#endregion
+
+namespace WebLinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Net.Http.Headers;
+    using System.Net;
+    using System.Net.Http;
+
+    // Inspiration & credit:
+    // https://github.com/dotnet/corefx/blob/e0ba7aa8026280ee3571179cc06431baf1dfaaac/src/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
+    //
+    //
+    // - System.System.Net.Http.FormUrlEncodedContent(...) can't handle very long parameters/values
+    //   https://github.com/dotnet/corefx/issues/1936
+
+    sealed class FormUrlEncodedContent : ByteArrayContent
+    {
+        public FormUrlEncodedContent(IEnumerable<KeyValuePair<string, string>> nameValueCollection) :
+            base(GetContentByteArray(nameValueCollection)) =>
+            Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
+
+        static readonly Encoding DefaultHttpEncoding = Encoding.GetEncoding("iso-8859-1");
+
+        static byte[] GetContentByteArray(IEnumerable<KeyValuePair<string, string>> nameValueCollection)
+        {
+            if (nameValueCollection == null)
+                throw new ArgumentNullException(nameof(nameValueCollection));
+
+            // Encode and concatenate data
+            var builder = new StringBuilder();
+            foreach (var pair in nameValueCollection)
+            {
+                if (builder.Length > 0)
+                    builder.Append('&');
+
+                builder.Append(Encode(pair.Key));
+                builder.Append('=');
+                builder.Append(Encode(pair.Value));
+            }
+
+            return DefaultHttpEncoding.GetBytes(builder.ToString());
+        }
+
+        static string Encode(string data) =>
+            string.IsNullOrEmpty(data)
+            ? string.Empty
+            : WebUtility.UrlEncode(data).Replace("%20", "+"); // Escape spaces as '+'.
+    }
+}

--- a/src/Core/WebLinq.csproj
+++ b/src/Core/WebLinq.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Collections\MapBase.cs" />
     <Compile Include="Collections\Map.cs" />
     <Compile Include="ArrayList.cs" />
+    <Compile Include="FormUrlEncodedContent.cs" />
     <Compile Include="Html\HtmlForm.cs" />
     <Compile Include="Html\HtmlFormControl.cs" />
     <Compile Include="Html\HtmlParser.cs" />

--- a/src/Core/WebLinq.nuspec
+++ b/src/Core/WebLinq.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/atifaziz/WebLinq</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Library enabling web scraping over LINQ.</description>
-    <copyright>Copyright &#xa9; 2016 Atif Aziz. All rights reserved.</copyright>
+    <copyright>Copyright &#xa9; 2016 Atif Aziz. Portions Copyright &#xa9; .NET Foundation and Contributors. All rights reserved.</copyright>
     <tags>linq web www query</tags>
     <releaseNotes>Commit @ $RepoCommit$</releaseNotes>
   </metadata>

--- a/tests/HttpQueryTests.cs
+++ b/tests/HttpQueryTests.cs
@@ -1382,13 +1382,18 @@
         }
 
         [Test(Description = "https://github.com/weblinq/WebLinq/issues/19")]
-        public async Task PostLargeData()
+        [TestCase(30_000)]
+        [TestCase(33_000)]
+        [TestCase(64_000)]
+        [TestCase(65_000)]
+        [TestCase(70_000)]
+        public async Task PostLargeData(int size)
         {
             var tt = new TestTransport().Enqueue(new byte[0]);
 
             await tt.Http.Post(new Uri("https://www.example.com/"), new NameValueCollection
             {
-                ["foo"] = new string('*', 70_000)
+                ["foo"] = new string('*', size)
             });
 
             Assert.Pass();

--- a/tests/HttpQueryTests.cs
+++ b/tests/HttpQueryTests.cs
@@ -1381,6 +1381,19 @@
             Assert.That(await message.Content.ReadAsStringAsync(), Is.EqualTo("firstname=Mickey&lastname=Mouse"));
         }
 
+        [Test(Description = "https://github.com/weblinq/WebLinq/issues/19")]
+        public async Task PostLargeData()
+        {
+            var tt = new TestTransport().Enqueue(new byte[0]);
+
+            await tt.Http.Post(new Uri("https://www.example.com/"), new NameValueCollection
+            {
+                ["foo"] = new string('*', 70_000)
+            });
+
+            Assert.Pass();
+        }
+
         [TestCase(HttpStatusCode.Ambiguous)]
         [TestCase(HttpStatusCode.Moved)]
         [TestCase(HttpStatusCode.Redirect)]


### PR DESCRIPTION
This is caused by [`Uri.EscapeDataString`](https://docs.microsoft.com/en-us/dotnet/api/system.uri.escapedatastring?view=netframework-4.7.2) limiting the string to escape to a little shy of 64K, though the documentation claims that the actual limitation is even half of that:

> The length of `stringToEscape` exceeds 32766 characters.

This PR is a fix for #19.
